### PR TITLE
Fix #17: Reduce memory usage in Indexer by storing indices instead of…

### DIFF
--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,0 +1,67 @@
+import pytest
+from jflatdb.indexer import Indexer  # Import Indexer from the package
+
+# Sample dataset for testing
+data = [
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 25},
+    {"name": "Alice", "age": 25},
+    {"name": "Charlie", "age": 30},
+]
+
+def test_build_store_full():
+    """
+    Test that build() stores full records when store_full=True
+    """
+    indexer = Indexer()
+    indexer.build(data, store_full=True)
+    
+    # The stored items should be dicts (full records)
+    assert isinstance(indexer.indexes["name"]["Alice"][0], dict)
+    # Check that there are 2 records with age 30
+    assert len(indexer.indexes["age"][30]) == 2
+
+def test_build_store_indices():
+    """
+    Test that build() stores only indices when store_full=False
+    """
+    indexer = Indexer()
+    indexer.build(data, store_full=False)
+    
+    # The stored items should be integers (indices)
+    assert isinstance(indexer.indexes["name"]["Alice"][0], int)
+    
+    # Query using the index should return correct records
+    results = indexer.query({"name": "Alice", "age": 25}, use_index=True)
+    assert results == [{"name": "Alice", "age": 25}]
+
+def test_query_without_index():
+    """
+    Test query() fallback when use_index=False
+    """
+    indexer = Indexer()
+    indexer.build(data, store_full=False)
+    
+    results = indexer.query({"name": "Bob", "age": 25}, use_index=False)
+    assert results == [{"name": "Bob", "age": 25}]
+
+def test_query_missing_key():
+    """
+    Test query() when the key is missing in indexes
+    """
+    indexer = Indexer()
+    indexer.build(data, store_full=False)
+    
+    results = indexer.query({"city": "NY"}, use_index=True)
+    # Should fallback to scanning and return empty list
+    assert results == []
+
+def test_query_multiple_conditions():
+    """
+    Test query() with multiple conditions
+    """
+    indexer = Indexer()
+    indexer.build(data, store_full=False)
+    
+    results = indexer.query({"name": "Alice", "age": 30}, use_index=True)
+    assert results == [{"name": "Alice", "age": 30}]


### PR DESCRIPTION
Problem:
The Indexer currently stores full record objects in its index, duplicating memory across fields. For large datasets, this causes high memory usage and inefficiency.

Solution:

Added a store_full parameter to build() (default False):

store_full=True → original behavior (store full records)

store_full=False → store only record indices to save memory

Original dataset is kept in self.data so queries still return full records correctly.

query() works seamlessly with both modes.

Tests:

Added tests/test_indexer.py to verify:

Memory-efficient indexing

Full-record indexing

Queries with multiple conditions

Missing keys

Index-based queries

Impact:

Memory usage is significantly reduced for large datasets.

Query results remain correct.

Fully backward-compatible.

Issue:
Fixes #17